### PR TITLE
Add "queue" method

### DIFF
--- a/geotriggers.js
+++ b/geotriggers.js
@@ -42,6 +42,7 @@
   }
 
   function Session(options){
+    this._queue = [];
     this._requestQueue = [];
     this._events = {};
 
@@ -129,6 +130,10 @@
         this.persist();
       }
 
+      while(this._queue.length){
+        this._queue.shift().apply(this);
+      }
+
       while(this._requestQueue.length){
         this.request.apply(this, this._requestQueue.shift());
       }
@@ -175,6 +180,18 @@
         }
       }
     }
+  };
+
+  Session.prototype.queue = function(fn) {
+    var args = Array.prototype.slice.apply(arguments);
+
+    if (!this.token) {
+      this._queue.push(args);
+      this.refresh();
+      return;
+    }
+
+    fn.apply(this);
   };
 
   Session.prototype.request = function(method, params, callback){


### PR DESCRIPTION
This method would allow you to have access to session variables in an arbitrary function once the session's been instantiated by the server response.

Example:

``` js
var session = new Geotriggers.Session({
  clientId: 'XXXXXX'
});

console.log(this.deviceId); // undefined

session.queue(function(){
  console.log(this.deviceId); // actual deviceId
});
```
