### PR TITLE
need workaround for authenticating when testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@ tmp
 .yardoc
 _yardoc
 doc/
+
+spec/config.js

--- a/README.md
+++ b/README.md
@@ -274,6 +274,7 @@ A Node.js proxy is supplied in the `proxy` folder. To create your own proxy to s
 1. `cd` into the `geotrigger-js` folder
 1. Install dependencies with `npm install`
 1. Run tests with `npm test` or `grunt test`
+    * first `cp spec/config.js.example spec/config.js` and add valid `clientId` & `clientSecret`
 1. Make your changes and create a [pull request](https://help.github.com/articles/creating-a-pull-request)
 
 ## Resources

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -9,6 +9,7 @@ files = [
   JASMINE,
   JASMINE_ADAPTER,
   {pattern: 'geotrigger.js'},
+  {pattern: 'spec/config.js'},
   {pattern: 'spec/SpecHelpers.js'},
   {pattern: 'spec/GeotriggerSpec.js'}
 ];

--- a/spec/GeotriggerSpec.js
+++ b/spec/GeotriggerSpec.js
@@ -1,19 +1,20 @@
 if(typeof module === "object"){
   var Geotrigger = require("../geotrigger");
+  var config = require("./config");
 }
 
-var ClientId = "ABC";
-var ClientSecret = "XYZ";
+var ClientId = config.clientId;
+var ClientSecret = config.clientSecret;
 
 describe("geotrigger.js", function() {
 
-  it("should throw an error if initialized without an application_id or session", function(){
+  it("should throw an error if initialized without a client id or session", function(){
     expect(function(){
       var geotriggers = new Geotrigger.Session();
     }).toThrow();
   });
 
-  it("should fire an `authenticated` event after the initializes successfully with an application id and secret", function(){
+  it("should fire an `authenticated` event after initializing successfully with a client id and secret", function(){
 
     var spy = jasmine.createSpy();
     var geotriggers;
@@ -37,7 +38,7 @@ describe("geotrigger.js", function() {
     });
   });
 
-  it("should fire an `authenticated` event after the initializes successfully with an application id", function(){
+  it("should fire an `authenticated` event after initializing successfully with a client id", function(){
     var spy = jasmine.createSpy();
     var geotriggers;
 
@@ -93,7 +94,7 @@ describe("geotrigger.js", function() {
       });
     });
 
-    it("should update a device and use a deferred", function(){
+    it("should be able to update a device", function(){
       var spy = jasmine.createSpy();
 
       runs(function(){

--- a/spec/config.js.example
+++ b/spec/config.js.example
@@ -1,0 +1,22 @@
+(function (root, factory) {
+
+  // Node.
+  if (typeof module === 'object' && typeof module.exports === 'object') {
+    exports = module.exports = factory();
+  }
+
+  // Browser Global.
+  if (typeof window === 'object') {
+    root.config = factory();
+  }
+
+}(this, function() {
+
+  // add your clientId and clientSecret here
+  var config = {
+    "clientId": "ABC",
+    "clientSecret": "XYZ"
+  };
+
+  return config;
+}));


### PR DESCRIPTION
Tests don't work right now. Since we can't commit credentials for testing purposes, we need a good workaround to allow anyone to run tests. A simple way to do this would be to have a `config.json.dist` file in the test directory and to ignore a local copy of config.json with user credentials. @chelm has a similar solution in https://github.com/ArcGIS/arcgis-js#testing of just including an example auth.js.example file in the test directory and asking users to copy it.
