### PR TITLE
mr. sparkle for changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,51 +1,47 @@
-# Geotrigger.js Changelog
+# Change Log
+All notable changes to this project will be documented in this file.
+This project adheres to [Semantic Versioning](http://semver.org/).
 
-# 1.0.1
+## [Unreleased]
+
+## [1.0.1] - 2014-10-10
+### Fixed
 * Change token & device registration URLs to use load balancer ([#39](https://github.com/Esri/geotrigger-js/pull/39))
 
-# 1.0.0
-* Add tracking headers for usage reporting
+## [1.0.0] - 2014-2-21
+### Added
+* tracking headers for usage reporting
 
-# 0.1.5
+## [0.1.5] - 2013-12-31
+### Added
+* test config
+* `authentication:restored` event
+
+### Fixed
 * Fixed a bug where a session created with `clientId` and a `refreshToken` would not properly reauthenticate with AGO if a session expired.
-* add test config
-* add `authentication:restored` event
 
-## 0.1.4
+## [0.1.4] - 2013-11-20
+### Fixed
 * Fix bug where http errors without JSON responses would not be handled
 
-## 0.1.3
+## [0.1.3] - 2013-11-20
+### Fixed
 * Fix bug where http errors would not be handled
 
-## 0.1.2
-* First public release
+## [0.1.2] - 2013-11-19
 
-## 0.1.1
-* Small bugfixes
+First public release
 
-## 0.1.0
+## 0.1.0 - 2013-11-19
+### Fixed
 * Bump verion to prep for beta release of the Geotrigger Service
 
-## 0.0.4
-* Fix incorrect reference to deviceId
-* Add proxy support
-* Add `queue` method
-* Fix broken CORS check in IE 10
 
-## 0.0.3
-* Minor bugfixes.
-* Remove deferreds. All `request` now only accepts callbacks.
-* Remove context param from `request` to allow for other promise libaries ot promisify `request`
+[Unreleased]: https://github.com/Esri/geotrigger-js/compare/v1.0.1...HEAD
+[1.0.1]: https://github.com/Esri/geotrigger-js/compare/v1.0.0...v1.0.1
+[1.0.0]: https://github.com/Esri/geotrigger-js/compare/v0.1.5...v1.0.0
+[0.1.5]: https://github.com/Esri/geotrigger-js/compare/v0.1.4...v0.1.5
+[0.1.4]: https://github.com/Esri/geotrigger-js/compare/v0.1.3...v0.1.4
+[0.1.3]: https://github.com/Esri/geotrigger-js/compare/v0.1.2...v0.1.3
+[0.1.2]: https://github.com/Esri/geotrigger-js/compare/v0.1.0...v0.1.2
 
-## 0.0.2
-* Removes `session.get(method, options)` and `session.post(method, options)` methods. Use `session.request(method, options)` instead.
-* All requests now use POST to talk to the API.
-* `token` is set in request bodies (was sending authorization header previously)
-* Stop trying to refresh token after 3 failed attempts.
-* Less confusing invocation of callback if provided.
-* Should work in IE8 and IE9 but will not refresh tokens or register devices with ArcGIS
-* You can no longer set `accessToken` when creating a session. Use `token` instead.
-* Passing `session` when creating a session no longer works. Instead anything you set on the options object passed into `new Geotrigger.Session(options)` will be merged into the session. This means that going `session.toJSON()` will give you the proper options object to restore a session.
-
-## 0.0.1
-Initial Release

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "xmlhttprequest": "~1.5.0"
   },
   "devDependencies": {
+    "gh-release": "2.0.2",
     "grunt": "~0.4.1",
     "grunt-contrib-jshint": "~0.4.3",
     "grunt-contrib-uglify": "~0.2.0",


### PR DESCRIPTION
* got rid of information about tagged releases which are longer published
* reformatted

with this we're primed to use `gh-release` next time around.